### PR TITLE
Fix potential error when deleting remote files in sync manager

### DIFF
--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -543,7 +543,9 @@ export default class SyncManager {
             break;
           }
           case "delete_remote": {
-            newTreeFiles[action.filePath].sha = null;
+            if (newTreeFiles[action.filePath]) {
+              newTreeFiles[action.filePath].sha = null;
+            }
             break;
           }
           case "download":


### PR DESCRIPTION
## Summary
Fix sync error when deleting files on Android and syncing with macOS

## Issue
Closes #21

When deleting files on Android and then syncing with github repo pushed from macOS, a sync error occurs as described in the linked issue.

## Notes
There may be potential to remove the `.sha = null` setting entirely, but the side effects are unclear for me.