### PR TITLE
Updated boolean for non-deletion cases in SyncManager determineSyncActions method

### DIFF
--- a/mock-obsidian.ts
+++ b/mock-obsidian.ts
@@ -156,7 +156,7 @@ export function arrayBufferToBase64(buffer: ArrayBuffer): string {
 }
 
 export function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  return Buffer.from(base64, "base64");
+  return Buffer.from(base64, "base64").buffer;
 }
 
 // Mock Event reference

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -729,7 +729,7 @@ export default class SyncManager {
         if (localSHA !== localFile.sha && remoteFile.lastModified < localFile.lastModified) {
           actions.push({ type: "upload", filePath: filePath });
           return;
-        } else if(localSHA == localFile.sha && remoteFile.lastModified > localFile.lastModified) {
+        } else if(remoteFile.lastModified > localFile.lastModified) {
           actions.push({ type: "download", filePath: filePath });
           return;
         }

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -724,12 +724,12 @@ export default class SyncManager {
           }
         }
 
-        // For non-deletion cases, if SHAs differ, we just need to check if local changed.
+        // For non-deletion cases, if SHAs differ, we need to check if local changed and what file was modified last
         // Conflicts are already filtered out so we can make this decision easily
-        if (localSHA !== localFile.sha) {
+        if (localSHA !== localFile.sha && remoteFile.lastModified < localFile.lastModified) {
           actions.push({ type: "upload", filePath: filePath });
           return;
-        } else {
+        } else if(localSHA == localFile.sha && remoteFile.lastModified > localFile.lastModified) {
           actions.push({ type: "download", filePath: filePath });
           return;
         }

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -261,7 +261,7 @@ export default class SyncManager {
         }
 
         const normalizedPath = normalizePath(targetPath);
-        await this.vault.adapter.writeBinary(normalizedPath, data);
+        await this.vault.adapter.writeBinary(normalizedPath, data.buffer);
         await this.logger.info("Written file", {
           normalizedPath,
         });


### PR DESCRIPTION
I put together this fix, it has to do with this Issue: #37 

here is some context:
**Description**
When I change any file in the vault it syncs properly but then after it syncs if I don't change that file before next sync it undoes my sync. I've been trying to use this plugin for a small team of devs so we can utilize the Kanban plugin Obsidian has and I can confirm two different machines, one on MacOS and one on Windows 11, have this problem.

**Steps to reproduce**
1. Sync a notes file
2. Change the notes file
3. Sync the notes file
4. Sync the notes file again
5. See unchanged notes file

**Copied Logs**
```logs
{"timestamp":"2025-09-17T18:14:21.205Z","level":"INFO","message":"Received modify event","additional_data":"StorySquad FE General.md"}
{"timestamp":"2025-09-17T18:14:21.212Z","level":"INFO","message":"Updated modified file","additional_data":"StorySquad FE General.md"}
{"timestamp":"2025-09-17T18:14:27.207Z","level":"INFO","message":"Starting sync"}
{"timestamp":"2025-09-17T18:14:27.503Z","level":"INFO","message":"Actions to sync","additional_data":[{"type":"upload","filePath":"StorySquad FE General.md"}]}
{"timestamp":"2025-09-17T18:14:28.767Z","level":"INFO","message":"Sync done"}
{"timestamp":"2025-09-17T18:14:30.189Z","level":"INFO","message":"Starting sync"}
{"timestamp":"2025-09-17T18:14:30.208Z","level":"INFO","message":"Actions to sync","additional_data":[{"type":"download","filePath":"StorySquad FE General.md"}]}
{"timestamp":"2025-09-17T18:14:30.377Z","level":"INFO","message":"Received modify event","additional_data":"StorySquad FE General.md"}
{"timestamp":"2025-09-17T18:14:30.379Z","level":"INFO","message":"Updated just downloaded modified file","additional_data":"StorySquad FE General.md"}
{"timestamp":"2025-09-17T18:14:31.489Z","level":"INFO","message":"Sync done"}
{"timestamp":"2025-09-17T18:14:33.921Z","level":"INFO","message":"Starting sync"}
{"timestamp":"2025-09-17T18:14:33.961Z","level":"INFO","message":"Nothing to sync"}
```

I looked into it and it seems that in the file `src/sync-manager.ts` there's an if-else statement on line 729 that only checks if the `localSHA !== localFile.sha`. I believe it would be more accurate to also check `remoteFile.lastModified < localFile.lastModified`, as well as adding an else-if to the latter block to ensure that `localSHA == localFile.sha && remoteFile.lastModified > localFile.lastModified` evaluates to true before downloading the file.

**Original code**
```TypeScript
if (localSHA !== localFile.sha) {
  actions.push({ type: "upload", filePath: filePath });
  return;
} else {
  actions.push({ type: "download", filePath: filePath });
  return;
}
```

**My (somewhat) tested & modified code**
```TypeScript
if (localSHA !== localFile.sha && remoteFile.lastModified < localFile.lastModified) {
  actions.push({ type: "upload", filePath: filePath });
  return;
} else if(localSHA == localFile.sha && remoteFile.lastModified > localFile.lastModified) {
  actions.push({ type: "download", filePath: filePath });
  return;
}
```
