### PR TITLE
Fix: Detect files modified directly on GitHub

### DIFF
--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -440,6 +440,40 @@ export default class SyncManager {
       decodeBase64String(blob.content),
     );
 
+    // Detect files modified directly on GitHub (via web UI or other means).
+    // The manifest only updates when syncing through this plugin, so we compare
+    // actual tree SHAs with manifest SHAs to catch external modifications.
+    await this.logger.info("Checking for remote changes outside manifest");
+    Object.keys(files).forEach((filePath: string) => {
+      if (filePath === `${this.vault.configDir}/${MANIFEST_FILE_NAME}`) {
+        return;
+      }
+      
+      const actualRemoteSHA = files[filePath].sha;
+      const manifestEntry = remoteMetadata.files[filePath];
+      
+      if (manifestEntry) {
+        if (manifestEntry.sha !== actualRemoteSHA) {
+          this.logger.info("Detected external change", {
+            filePath,
+            manifestSHA: manifestEntry.sha,
+            actualSHA: actualRemoteSHA,
+          });
+          manifestEntry.sha = actualRemoteSHA;
+          manifestEntry.lastModified = Date.now();
+        }
+      } else {
+        this.logger.info("Detected new file added externally", { filePath });
+        remoteMetadata.files[filePath] = {
+          path: filePath,
+          sha: actualRemoteSHA,
+          dirty: false,
+          justDownloaded: false,
+          lastModified: Date.now(),
+        };
+      }
+    });
+
     const conflicts = await this.findConflicts(remoteMetadata.files);
 
     // We treat every resolved conflict as an upload SyncAction, mainly cause


### PR DESCRIPTION
## Problem

Fixes #45

When files are edited directly on GitHub (via web UI or other means outside the plugin), the plugin fails to detect these changes during sync. The user sees "Nothing to sync" even though files have been modified remotely.

### Root Cause

The plugin uses a manifest file (`github-sync-metadata.json`) to track file SHAs. The manifest only updates when syncing through this plugin. When someone edits a file directly on GitHub:

1. The file's SHA in the git tree changes
2. The manifest file's SHA remains the same (old value)
3. The sync logic only compares manifest-to-manifest
4. **Result:** Remote changes are invisible to the plugin

## Solution

After fetching the remote manifest, we now compare:
- **Actual remote file SHAs** (from the git tree via `getRepoContent()`)
- **Manifest-recorded SHAs** (from the manifest blob)

If they differ, we update the manifest entry to reflect the actual state. This allows `determineSyncActions()` to detect the change and trigger a download.

### Changes Made

```typescript
// New logic in syncImpl() after loading remote metadata:
Object.keys(files).forEach((filePath: string) => {
  const actualRemoteSHA = files[filePath].sha;
  const manifestEntry = remoteMetadata.files[filePath];
  
  if (manifestEntry && manifestEntry.sha !== actualRemoteSHA) {
    // File was modified externally - update manifest
    manifestEntry.sha = actualRemoteSHA;
    manifestEntry.lastModified = Date.now();
  } else if (!manifestEntry) {
    // New file added externally - add to manifest
    remoteMetadata.files[filePath] = { ... };
  }
});
```

## Testing

✅ **Tested and verified working:**

1. Synced a note to GitHub via the plugin
2. Edited the note directly on GitHub web UI
3. Triggered sync in Obsidian (mobile)
4. **Result:** Updated content downloaded successfully

**Before fix:** "Nothing to sync"  
**After fix:** File detected and downloaded

### Test Environment
- Obsidian Mobile (iOS/Android)
- Plugin version: 1.0.8-beta.1
- Original reporter (@tohizma) and @TheOutdoorProgrammer confirmed fix works

## Impact

- **No breaking changes** - only adds detection logic
- **Minimal code change** - ~30 lines in `sync-manager.ts`
- **Preserves existing behavior** - all existing sync scenarios still work
- **Fixes edge case** - now handles external modifications correctly

## Additional Notes

This fix handles two scenarios:
1. **Modified files:** SHA mismatch triggers update
2. **New files:** Missing manifest entry triggers addition

The manifest comment documents why this comparison is necessary - without it, future maintainers wouldn't understand the limitation of the manifest-based approach.