### PR TITLE
fix: set sha safely

### DIFF
--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -543,7 +543,9 @@ export default class SyncManager {
             break;
           }
           case "delete_remote": {
-            newTreeFiles[action.filePath].sha = null;
+            if (newTreeFiles[action.filePath]) {
+              newTreeFiles[action.filePath].sha = null;
+            }
             break;
           }
           case "download":
@@ -858,7 +860,18 @@ export default class SyncManager {
           // on them if it makes the plugin handle upload better on certain devices.
           if (hasTextExtension(filePath)) {
             const sha = await this.calculateSHA(filePath);
-            this.metadataStore.data.files[filePath].sha = sha;
+            if (this.metadataStore.data.files[filePath]) {
+              this.metadataStore.data.files[filePath].sha = sha;
+            } else {
+              this.metadataStore.data.files[filePath] = {
+                path: filePath,
+                sha: sha,
+                dirty: false,
+                justDownloaded: false,
+                lastModified: syncTime,
+                deleted: false,
+              };
+            }
             return;
           }
 
@@ -875,7 +888,18 @@ export default class SyncManager {
           treeFiles[filePath].sha = sha;
           // Can't have both sha and content set, so we delete it
           delete treeFiles[filePath].content;
-          this.metadataStore.data.files[filePath].sha = sha;
+          if (this.metadataStore.data.files[filePath]) {
+            this.metadataStore.data.files[filePath].sha = sha;
+          } else {
+            this.metadataStore.data.files[filePath] = {
+              path: filePath,
+              sha: sha,
+              dirty: false,
+              justDownloaded: false,
+              lastModified: syncTime,
+              deleted: false,
+            };
+          }
         }),
     );
 


### PR DESCRIPTION
Hi @silvanocerza, thank you very much for your work on this amazing Obsidian Plugin!

I find it very useful especially when using on mobile. Unfortunately, sometimes mobile sync was failing for me with this error:

```shel
Error syncing. TypeError: Cannot set properties of undefined (setting 'sha')
```

Eventually, I added guards in three places, installed and tested the plugin using [BRAT](https://github.com/TfTHacker/obsidian42-brat).

Please take a look at this patch when you have some time.