### PR TITLE
Add option to sync workspace files

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@uiw/react-codemirror": "^4.23.8",
     "@zip.js/zip.js": "^2.7.60",
     "codemirror": "^6.0.1",
+    "ignore": "5.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       codemirror:
         specifier: ^6.0.1
         version: 6.0.1
+      ignore:
+        specifier: 5.3.2
+        version: 5.3.2
       react:
         specifier: ^19.0.0
         version: 19.0.0

--- a/src/events-listener.ts
+++ b/src/events-listener.ts
@@ -169,8 +169,8 @@ export default class EventsListener {
       return false;
     }
 
-    // O ficheiro pode mudar durante a sessão, por isso os eventos leem sempre
-    // a versão atual antes de decidir se atualizam o manifesto local.
+    // The file can change during the session, so events always read
+    // the current version before deciding whether to update local metadata.
     return isGitignored(await loadGitignoreMatcher(this.vault), filePath);
   }
 }

--- a/src/events-listener.ts
+++ b/src/events-listener.ts
@@ -3,6 +3,7 @@ import MetadataStore, { MANIFEST_FILE_NAME } from "./metadata-store";
 import { GitHubSyncSettings } from "./settings/settings";
 import Logger, { LOG_FILE_NAME } from "./logger";
 import GitHubSyncPlugin from "./main";
+import { isGitignored, loadGitignoreMatcher } from "./gitignore";
 
 /**
  * Tracks changes to local sync directory and updates files metadata.
@@ -27,7 +28,7 @@ export default class EventsListener {
 
   private async onCreate(file: TAbstractFile) {
     await this.logger.info("Received create event", file.path);
-    if (!this.isSyncable(file.path)) {
+    if (!(await this.isSyncable(file.path))) {
       // The file has not been created in directory that we're syncing with GitHub
       await this.logger.info("Skipped created file", file.path);
       return;
@@ -66,7 +67,7 @@ export default class EventsListener {
       // Skip folders
       return;
     }
-    if (!this.isSyncable(filePath)) {
+    if (!(await this.isSyncable(filePath))) {
       // The file was not in directory that we're syncing with GitHub
       return;
     }
@@ -79,7 +80,7 @@ export default class EventsListener {
 
   private async onModify(file: TAbstractFile) {
     await this.logger.info("Received modify event", file.path);
-    if (!this.isSyncable(file.path)) {
+    if (!(await this.isSyncable(file.path))) {
       // The file has not been create in directory that we're syncing with GitHub
       await this.logger.info("Skipped modified file", file.path);
       return;
@@ -112,30 +113,33 @@ export default class EventsListener {
       // Skip folders
       return;
     }
-    if (!this.isSyncable(file.path) && !this.isSyncable(oldPath)) {
+    const newFileIsSyncable = await this.isSyncable(file.path);
+    const oldFileIsSyncable = await this.isSyncable(oldPath);
+
+    if (!newFileIsSyncable && !oldFileIsSyncable) {
       // Both are not in directory that we're syncing with GitHub
       return;
     }
 
-    if (this.isSyncable(file.path) && this.isSyncable(oldPath)) {
+    if (newFileIsSyncable && oldFileIsSyncable) {
       // Both files are in the synced directory
       // First create the new one
       await this.onCreate(file);
       // Then delete the old one
       await this.onDelete(oldPath);
       return;
-    } else if (this.isSyncable(file.path)) {
+    } else if (newFileIsSyncable) {
       // Only the new file is in the local directory
       await this.onCreate(file);
       return;
-    } else if (this.isSyncable(oldPath)) {
+    } else if (oldFileIsSyncable) {
       // Only the old file was in the local directory
       await this.onDelete(oldPath);
       return;
     }
   }
 
-  private isSyncable(filePath: string) {
+  private async isSyncable(filePath: string) {
     if (filePath === `${this.vault.configDir}/${MANIFEST_FILE_NAME}`) {
       // Manifest file must always be synced
       return true;
@@ -153,10 +157,20 @@ export default class EventsListener {
       filePath.startsWith(this.vault.configDir)
     ) {
       // Sync configs only if the user explicitly wants to
-      return true;
+      return !(await this.isIgnored(filePath));
     } else {
       // All other files can be synced
-      return true;
+      return !(await this.isIgnored(filePath));
     }
+  }
+
+  private async isIgnored(filePath: string): Promise<boolean> {
+    if (!this.settings.useGitignore) {
+      return false;
+    }
+
+    // O ficheiro pode mudar durante a sessão, por isso os eventos leem sempre
+    // a versão atual antes de decidir se atualizam o manifesto local.
+    return isGitignored(await loadGitignoreMatcher(this.vault), filePath);
   }
 }

--- a/src/events-listener.ts
+++ b/src/events-listener.ts
@@ -135,16 +135,21 @@ export default class EventsListener {
     }
   }
 
+  private isWorkspaceFile(filePath: string): boolean {
+    return (
+      filePath === `${this.vault.configDir}/workspace.json` ||
+      filePath === `${this.vault.configDir}/workspace-mobile.json`
+    );
+  }
+
   private isSyncable(filePath: string) {
     if (filePath === `${this.vault.configDir}/${MANIFEST_FILE_NAME}`) {
       // Manifest file must always be synced
       return true;
-    } else if (
-      filePath === `${this.vault.configDir}/workspace.json` ||
-      filePath === `${this.vault.configDir}/workspace-mobile.json`
-    ) {
-      // Obsidian recommends not syncing the workspace files
-      return false;
+    } else if (this.isWorkspaceFile(filePath)) {
+      // Workspace files are synced only when config directory sync is enabled
+      // and the dedicated workspace-files option is enabled too.
+      return this.settings.syncConfigDir && this.settings.syncWorkspaceFiles;
     } else if (filePath === `${this.vault.configDir}/${LOG_FILE_NAME}`) {
       // Don't sync the log file, doesn't make sense
       return false;

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -1,0 +1,43 @@
+import { Vault, normalizePath } from "obsidian";
+import ignore, { Ignore } from "ignore";
+
+export const GITIGNORE_FILE_NAME = ".gitignore" as const;
+
+export function createGitignoreMatcher(patterns = ""): Ignore {
+  return ignore().add(patterns);
+}
+
+/**
+ * Carrega as regras da raiz do cofre e devolve um matcher equivalente ao gitignore.
+ */
+export async function loadGitignoreMatcher(vault: Vault): Promise<Ignore> {
+  const matcher = createGitignoreMatcher();
+  const gitignorePath = normalizePath(GITIGNORE_FILE_NAME);
+
+  if (await vault.adapter.exists(gitignorePath)) {
+    matcher.add(await vault.adapter.read(gitignorePath));
+  }
+
+  return matcher;
+}
+
+/**
+ * Normaliza caminhos do Obsidian para o formato relativo esperado pelo parser.
+ */
+export function isGitignored(
+  matcher: Ignore | null,
+  filePath: string,
+  isDirectory = false,
+): boolean {
+  if (!matcher || filePath === "") {
+    return false;
+  }
+
+  const normalizedPath = normalizePath(filePath);
+  const pathToTest =
+    isDirectory && !normalizedPath.endsWith("/")
+      ? `${normalizedPath}/`
+      : normalizedPath;
+
+  return matcher.ignores(pathToTest);
+}

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -8,7 +8,7 @@ export function createGitignoreMatcher(patterns = ""): Ignore {
 }
 
 /**
- * Carrega as regras da raiz do cofre e devolve um matcher equivalente ao gitignore.
+ * Loads root vault rules and returns a matcher equivalent to gitignore.
  */
 export async function loadGitignoreMatcher(vault: Vault): Promise<Ignore> {
   const matcher = createGitignoreMatcher();
@@ -22,7 +22,7 @@ export async function loadGitignoreMatcher(vault: Vault): Promise<Ignore> {
 }
 
 /**
- * Normaliza caminhos do Obsidian para o formato relativo esperado pelo parser.
+ * Normalizes Obsidian paths to the relative format expected by the parser.
  */
 export function isGitignored(
   matcher: Ignore | null,

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -4,6 +4,7 @@ export interface GitHubSyncSettings {
   githubOwner: string;
   githubRepo: string;
   githubBranch: string;
+  useGitignore: boolean;
   syncStrategy: "manual" | "interval";
   syncInterval: number;
   syncOnStartup: boolean;
@@ -22,6 +23,7 @@ export const DEFAULT_SETTINGS: GitHubSyncSettings = {
   githubOwner: "",
   githubRepo: "",
   githubBranch: "main",
+  useGitignore: false,
   syncStrategy: "manual",
   syncInterval: 1,
   syncOnStartup: false,

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -8,6 +8,7 @@ export interface GitHubSyncSettings {
   syncInterval: number;
   syncOnStartup: boolean;
   syncConfigDir: boolean;
+  syncWorkspaceFiles: boolean;
   conflictHandling: "overwriteLocal" | "ask" | "overwriteRemote";
   conflictViewMode: "default" | "unified" | "split";
   showStatusBarItem: boolean;
@@ -26,6 +27,7 @@ export const DEFAULT_SETTINGS: GitHubSyncSettings = {
   syncInterval: 1,
   syncOnStartup: false,
   syncConfigDir: false,
+  syncWorkspaceFiles: false,
   conflictHandling: "ask",
   conflictViewMode: "default",
   showStatusBarItem: true,

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -9,6 +9,7 @@ export interface GitHubSyncSettings {
   syncOnStartup: boolean;
   syncConfigDir: boolean;
   conflictHandling: "overwriteLocal" | "ask" | "overwriteRemote";
+  autoResolveLogConflicts: boolean;
   conflictViewMode: "default" | "unified" | "split";
   showStatusBarItem: boolean;
   showSyncRibbonButton: boolean;
@@ -27,6 +28,7 @@ export const DEFAULT_SETTINGS: GitHubSyncSettings = {
   syncOnStartup: false,
   syncConfigDir: false,
   conflictHandling: "ask",
+  autoResolveLogConflicts: true,
   conflictViewMode: "default",
   showStatusBarItem: true,
   showSyncRibbonButton: true,

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -190,9 +190,9 @@ export default class GitHubSyncSettingsTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName("Automatically resolve conflits in logs")
+      .setName("Automatically resolve conflicts in logs")
       .setDesc(
-        "Automatically resolves conflits in this plugin's logs prioritizing the local file",
+        "Automatically resolves conflicts in this plugin's logs prioritizing the local file",
       )
       .addToggle((toggle) => {
         toggle

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -189,6 +189,20 @@ export default class GitHubSyncSettingsTab extends PluginSettingTab {
           });
       });
 
+    new Setting(containerEl)
+      .setName("Automatically resolve conflits in logs")
+      .setDesc(
+        "Automatically resolves conflits in this plugin's logs prioritizing the local file",
+      )
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.autoResolveLogConflicts)
+          .onChange(async (value) => {
+            this.plugin.settings.autoResolveLogConflicts = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
     new Setting(containerEl).setName("Interface").setHeading();
 
     new Setting(containerEl)

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -91,6 +91,18 @@ export default class GitHubSyncSettingsTab extends PluginSettingTab {
           }),
       );
 
+    new Setting(containerEl)
+      .setName("Use .gitignore")
+      .setDesc("Ignore files as defined in .gitignore")
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.useGitignore)
+          .onChange(async (value) => {
+            this.plugin.settings.useGitignore = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
     new Setting(containerEl).setName("Sync").setHeading();
 
     const syncStrategies = {

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -168,6 +168,23 @@ export default class GitHubSyncSettingsTab extends PluginSettingTab {
           });
       });
 
+    new Setting(containerEl)
+      .setName("Sync workspace files")
+      .setDesc("Sync workspace.json and workspace-mobile.json files")
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.syncWorkspaceFiles)
+          .onChange(async (value) => {
+            this.plugin.settings.syncWorkspaceFiles = value;
+            if (value && this.plugin.settings.syncConfigDir) {
+              await this.plugin.syncManager.addConfigDirToMetadata();
+            } else if (!value) {
+              await this.plugin.syncManager.removeWorkspaceFilesFromMetadata();
+            }
+            await this.plugin.saveSettings();
+          });
+      });
+
     const conflictHandlingOptions = {
       overwriteLocal: "Overwrite local file",
       ask: "Ask",

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -85,8 +85,8 @@ export default class SyncManager {
   }
 
   private getZipEntryTargetPath(entry: Entry): string {
-    // Os ZIPs do GitHub incluem uma pasta raiz artificial; removemo-la para
-    // testar os padrões como caminhos relativos ao cofre.
+    // GitHub ZIPs include an artificial root folder; we remove it so patterns
+    // are tested as vault-relative paths.
     const pathParts = entry.filename.split("/");
     return pathParts.length > 1 ? pathParts.slice(1).join("/") : entry.filename;
   }
@@ -320,8 +320,8 @@ export default class SyncManager {
           return;
         }
 
-        // O .gitignore também é um ficheiro escondido, mas tem de ser
-        // descarregado para manter as mesmas regras em todos os cofres.
+        // .gitignore is also a hidden file, but it must be downloaded to keep
+        // the same rules across vaults.
         if (
           targetPath !== GITIGNORE_FILE_NAME &&
           targetPath.split("/").last()?.startsWith(".")

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -439,8 +439,11 @@ export default class SyncManager {
     const remoteMetadata: Metadata = JSON.parse(
       decodeBase64String(blob.content),
     );
+    await this.removeVolatileArtifactsFromLocalMetadata();
+    remoteMetadata.files = this.filterRemoteMetadataFiles(remoteMetadata.files);
+    await this.reconcileRemoteMetadataWithTree(remoteMetadata.files, files);
 
-    const conflicts = await this.findConflicts(remoteMetadata.files);
+    const conflicts = await this.findConflicts(remoteMetadata.files, files);
 
     // We treat every resolved conflict as an upload SyncAction, mainly cause
     // the user has complete freedom on the edits they can apply to the conflicting files.
@@ -574,6 +577,158 @@ export default class SyncManager {
     await this.commitSync(newTreeFiles, treeSha, conflictResolutions);
   }
 
+  private isInternalSyncFile(filePath: string): boolean {
+    return (
+      filePath === `${this.vault.configDir}/${MANIFEST_FILE_NAME}` ||
+      this.isLogFile(filePath)
+    );
+  }
+
+  private isLogFile(filePath: string): boolean {
+    return filePath === `${this.vault.configDir}/${LOG_FILE_NAME}`;
+  }
+
+  private isVolatileSyncArtifact(filePath: string): boolean {
+    return this.isLogFile(filePath);
+  }
+
+  private filterRemoteMetadataFiles(filesMetadata: {
+    [key: string]: FileMetadata;
+  }): {
+    [key: string]: FileMetadata;
+  } {
+    return Object.keys(filesMetadata).reduce(
+      (acc: { [key: string]: FileMetadata }, filePath: string) => {
+        if (this.isVolatileSyncArtifact(filePath)) {
+          return acc;
+        }
+        acc[filePath] = filesMetadata[filePath];
+        return acc;
+      },
+      {},
+    );
+  }
+
+  /**
+   * Remove artefactos volateis do metadata local para evitar conflitos recorrentes.
+   */
+  private async removeVolatileArtifactsFromLocalMetadata() {
+    let changed = false;
+    Object.keys(this.metadataStore.data.files).forEach((filePath: string) => {
+      if (this.isVolatileSyncArtifact(filePath)) {
+        delete this.metadataStore.data.files[filePath];
+        changed = true;
+      }
+    });
+    if (changed) {
+      await this.metadataStore.save();
+    }
+  }
+
+  /**
+   * Reconcilia SHAs do metadata remoto com a tree atual para remover referencias obsoletas.
+   */
+  private async reconcileRemoteMetadataWithTree(
+    remoteMetadataFiles: {
+      [key: string]: FileMetadata;
+    },
+    remoteRepoFiles: {
+      [key: string]: GetTreeResponseItem;
+    },
+  ) {
+    let updatedEntries = 0;
+    let updatedSha = 0;
+    Object.keys(remoteMetadataFiles).forEach((filePath: string) => {
+      const metadataFile = remoteMetadataFiles[filePath];
+      if (!metadataFile || metadataFile.deleted) {
+        return;
+      }
+      const remoteTreeFile = remoteRepoFiles[filePath];
+      if (!remoteTreeFile || !remoteTreeFile.sha) {
+        return;
+      }
+      if (metadataFile.sha !== remoteTreeFile.sha) {
+        metadataFile.sha = remoteTreeFile.sha;
+        updatedEntries += 1;
+        updatedSha += 1;
+      }
+    });
+    if (updatedEntries > 0) {
+      await this.logger.warn("Reconciled remote metadata with repository tree", {
+        updatedEntries,
+        updatedSha,
+      });
+    }
+  }
+
+  /**
+   * Tenta obter o blob pelo SHA do metadata e, em caso de 404, tenta pelo SHA atual da tree.
+   */
+  private async getRemoteFileContentWithFallback(
+    filePath: string,
+    metadataFile: FileMetadata,
+    remoteRepoFiles: {
+      [key: string]: GetTreeResponseItem;
+    },
+  ): Promise<string | null> {
+    if (!metadataFile || metadataFile.deleted) {
+      return null;
+    }
+
+    let sha = metadataFile.sha;
+    if (!sha) {
+      const remoteTreeFile = remoteRepoFiles[filePath];
+      if (!remoteTreeFile?.sha) {
+        return null;
+      }
+      sha = remoteTreeFile.sha;
+      metadataFile.sha = sha;
+    }
+
+    try {
+      const res = await this.client.getBlob({
+        sha,
+        retry: true,
+        maxRetries: 1,
+      });
+      return decodeBase64String(res.content);
+    } catch (err) {
+      if (err.status !== 404) {
+        throw err;
+      }
+    }
+
+    const remoteTreeFile = remoteRepoFiles[filePath];
+    if (!remoteTreeFile?.sha) {
+      await this.logger.warn("Blob SHA missing for remote file", {
+        filePath,
+        staleSha: sha,
+      });
+      return null;
+    }
+    if (remoteTreeFile.sha === sha) {
+      await this.logger.warn("Blob SHA not found for remote file", {
+        filePath,
+        sha,
+      });
+      return null;
+    }
+
+    await this.logger.warn("Recovering from stale blob SHA using tree SHA", {
+      filePath,
+      staleSha: sha,
+      treeSha: remoteTreeFile.sha,
+    });
+    metadataFile.sha = remoteTreeFile.sha;
+
+    const res = await this.client.getBlob({
+      sha: remoteTreeFile.sha,
+      retry: true,
+      maxRetries: 1,
+    });
+    return decodeBase64String(res.content);
+  }
+
   /**
    * Finds conflicts between local and remote files.
    * @param filesMetadata Remote files metadata
@@ -581,6 +736,8 @@ export default class SyncManager {
    */
   async findConflicts(filesMetadata: {
     [key: string]: FileMetadata;
+  }, remoteRepoFiles: {
+    [key: string]: GetTreeResponseItem;
   }): Promise<ConflictFile[]> {
     const commonFiles = Object.keys(filesMetadata).filter(
       (key) => key in this.metadataStore.data.files,
@@ -591,7 +748,7 @@ export default class SyncManager {
 
     const conflicts = await Promise.all(
       commonFiles.map(async (filePath: string) => {
-        if (filePath === `${this.vault.configDir}/${MANIFEST_FILE_NAME}`) {
+        if (this.isInternalSyncFile(filePath)) {
           // The manifest file is only internal, the user must not
           // handle conflicts for this
           return null;
@@ -624,28 +781,30 @@ export default class SyncManager {
       }),
     );
 
-    return await Promise.all(
+    const resolvedConflicts = await Promise.all(
       conflicts
         .filter((filePath): filePath is string => filePath !== null)
         .map(async (filePath: string) => {
-          // Load contents in parallel
-          const [remoteContent, localContent] = await Promise.all([
-            await (async () => {
-              const res = await this.client.getBlob({
-                sha: filesMetadata[filePath].sha!,
-                retry: true,
-                maxRetries: 1,
-              });
-              return decodeBase64String(res.content);
-            })(),
-            await this.vault.adapter.read(normalizePath(filePath)),
-          ]);
+          const remoteContent = await this.getRemoteFileContentWithFallback(
+            filePath,
+            filesMetadata[filePath],
+            remoteRepoFiles,
+          );
+          if (remoteContent === null) {
+            return null;
+          }
+          const localContent = await this.vault.adapter.read(
+            normalizePath(filePath),
+          );
           return {
             filePath,
             remoteContent,
             localContent,
           };
         }),
+    );
+    return resolvedConflicts.filter(
+      (conflict): conflict is ConflictFile => conflict !== null,
     );
   }
 
@@ -988,6 +1147,9 @@ export default class SyncManager {
           // Obsidian recommends not syncing the workspace file
           return;
         }
+        if (this.isVolatileSyncArtifact(filePath)) {
+          return;
+        }
 
         this.metadataStore.data.files[filePath] = {
           path: filePath,
@@ -1011,6 +1173,7 @@ export default class SyncManager {
       };
       this.metadataStore.save();
     }
+    await this.removeVolatileArtifactsFromLocalMetadata();
     await this.logger.info("Loaded metadata");
   }
 
@@ -1035,6 +1198,9 @@ export default class SyncManager {
     }
     // Add them to the metadata store
     files.forEach((filePath: string) => {
+      if (this.isVolatileSyncArtifact(filePath)) {
+        return;
+      }
       this.metadataStore.data.files[filePath] = {
         path: filePath,
         sha: null,

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -21,6 +21,13 @@ import Logger, { LOG_FILE_NAME } from "./logger";
 import { decodeBase64String, hasTextExtension } from "./utils";
 import GitHubSyncPlugin from "./main";
 import { BlobReader, Entry, Uint8ArrayWriter, ZipReader } from "@zip.js/zip.js";
+import { Ignore } from "ignore";
+import {
+  createGitignoreMatcher,
+  GITIGNORE_FILE_NAME,
+  isGitignored,
+  loadGitignoreMatcher,
+} from "./gitignore";
 
 interface SyncAction {
   type: "upload" | "download" | "delete_local" | "delete_remote";
@@ -67,6 +74,76 @@ export default class SyncManager {
       this.settings,
       this.logger,
     );
+  }
+
+  private async getGitignoreMatcher(): Promise<Ignore | null> {
+    if (!this.settings.useGitignore) {
+      return null;
+    }
+
+    return await loadGitignoreMatcher(this.vault);
+  }
+
+  private getZipEntryTargetPath(entry: Entry): string {
+    // Os ZIPs do GitHub incluem uma pasta raiz artificial; removemo-la para
+    // testar os padrões como caminhos relativos ao cofre.
+    const pathParts = entry.filename.split("/");
+    return pathParts.length > 1 ? pathParts.slice(1).join("/") : entry.filename;
+  }
+
+  private async getGitignoreMatcherFromZipEntries(
+    entries: Entry[],
+  ): Promise<Ignore | null> {
+    if (!this.settings.useGitignore) {
+      return null;
+    }
+
+    const gitignoreEntry = entries.find(
+      (entry) => this.getZipEntryTargetPath(entry) === GITIGNORE_FILE_NAME,
+    );
+    if (!gitignoreEntry || gitignoreEntry.directory) {
+      return createGitignoreMatcher();
+    }
+
+    const writer = new Uint8ArrayWriter();
+    await gitignoreEntry.getData!(writer);
+    return createGitignoreMatcher(new TextDecoder().decode(await writer.getData()));
+  }
+
+  private filterIgnoredFiles<T>(files: { [key: string]: T }, matcher: Ignore | null) {
+    return Object.keys(files).reduce(
+      (filteredFiles: { [key: string]: T }, filePath: string) => {
+        if (
+          filePath === `${this.vault.configDir}/${MANIFEST_FILE_NAME}` ||
+          !isGitignored(matcher, filePath)
+        ) {
+          filteredFiles[filePath] = files[filePath];
+        }
+        return filteredFiles;
+      },
+      {},
+    );
+  }
+
+  private async removeIgnoredFilesFromMetadata(matcher: Ignore | null) {
+    if (!matcher) {
+      return;
+    }
+
+    let hasChanges = false;
+    Object.keys(this.metadataStore.data.files).forEach((filePath: string) => {
+      if (
+        filePath !== `${this.vault.configDir}/${MANIFEST_FILE_NAME}` &&
+        isGitignored(matcher, filePath)
+      ) {
+        delete this.metadataStore.data.files[filePath];
+        hasChanges = true;
+      }
+    });
+
+    if (hasChanges) {
+      await this.metadataStore.save();
+    }
   }
 
   /**
@@ -194,6 +271,8 @@ export default class SyncManager {
     const zipBlob = new Blob([zipBuffer]);
     const reader = new ZipReader(new BlobReader(zipBlob));
     const entries = await reader.getEntries();
+    const gitignoreMatcher =
+      await this.getGitignoreMatcherFromZipEntries(entries);
 
     await this.logger.info("Extracting files from ZIP", {
       length: entries.length,
@@ -201,17 +280,17 @@ export default class SyncManager {
 
     await Promise.all(
       entries.map(async (entry: Entry) => {
-        // All repo ZIPs contain a root directory that contains all the content
-        // of that repo, we need to ignore that directory so we strip the first
-        // folder segment from the path
-        const pathParts = entry.filename.split("/");
-        const targetPath =
-          pathParts.length > 1 ? pathParts.slice(1).join("/") : entry.filename;
+        const targetPath = this.getZipEntryTargetPath(entry);
 
         if (targetPath === "") {
           // Must be the root folder, skip it.
           // This is really important as that would lead us to try and
           // create the folder "/" and crash Obsidian
+          return;
+        }
+
+        if (isGitignored(gitignoreMatcher, targetPath, entry.directory)) {
+          await this.logger.info("Skipping .gitignore match", targetPath);
           return;
         }
 
@@ -296,7 +375,10 @@ export default class SyncManager {
     await Promise.all(
       Object.keys(this.metadataStore.data.files)
         .filter((filePath: string) => {
-          return !Object.keys(files).contains(filePath);
+          return (
+            !Object.keys(files).contains(filePath) &&
+            !isGitignored(gitignoreMatcher, filePath)
+          );
         })
         .map(async (filePath: string) => {
           const normalizedPath = normalizePath(filePath);
@@ -338,6 +420,9 @@ export default class SyncManager {
     treeSha: string,
   ) {
     await this.logger.info("Starting first sync from local files");
+    const gitignoreMatcher = await this.getGitignoreMatcher();
+    await this.removeIgnoredFilesFromMetadata(gitignoreMatcher);
+
     const newTreeFiles = Object.keys(files)
       .map((filePath: string) => ({
         path: files[filePath].path,
@@ -358,7 +443,10 @@ export default class SyncManager {
           // We should not try to sync deleted files, this can happen when
           // the user renames or deletes files after enabling the plugin but
           // before syncing for the first time
-          return !this.metadataStore.data.files[filePath].deleted;
+          return (
+            !this.metadataStore.data.files[filePath].deleted &&
+            !isGitignored(gitignoreMatcher, filePath)
+          );
         })
         .map(async (filePath: string) => {
           const normalizedPath = normalizePath(filePath);
@@ -438,6 +526,12 @@ export default class SyncManager {
     const blob = await this.client.getBlob({ sha: manifest.sha });
     const remoteMetadata: Metadata = JSON.parse(
       decodeBase64String(blob.content),
+    );
+    const gitignoreMatcher = await this.getGitignoreMatcher();
+    await this.removeIgnoredFilesFromMetadata(gitignoreMatcher);
+    remoteMetadata.files = this.filterIgnoredFiles(
+      remoteMetadata.files,
+      gitignoreMatcher,
     );
 
     const conflicts = await this.findConflicts(remoteMetadata.files);
@@ -965,6 +1059,7 @@ export default class SyncManager {
   async loadMetadata() {
     await this.logger.info("Loading metadata");
     await this.metadataStore.load();
+    const gitignoreMatcher = await this.getGitignoreMatcher();
     if (Object.keys(this.metadataStore.data.files).length === 0) {
       await this.logger.info("Metadata was empty, loading all files");
       let files = [];
@@ -979,6 +1074,10 @@ export default class SyncManager {
           // Skip the config dir if the user doesn't want to sync it
           continue;
         }
+        if (isGitignored(gitignoreMatcher, folder, true)) {
+          await this.logger.info("Skipping .gitignore folder match", folder);
+          continue;
+        }
         const res = await this.vault.adapter.list(folder);
         files.push(...res.files);
         folders.push(...res.folders);
@@ -986,6 +1085,9 @@ export default class SyncManager {
       files.forEach((filePath: string) => {
         if (filePath === `${this.vault.configDir}/workspace.json`) {
           // Obsidian recommends not syncing the workspace file
+          return;
+        }
+        if (isGitignored(gitignoreMatcher, filePath)) {
           return;
         }
 
@@ -1010,6 +1112,8 @@ export default class SyncManager {
         lastModified: Date.now(),
       };
       this.metadataStore.save();
+    } else {
+      await this.removeIgnoredFilesFromMetadata(gitignoreMatcher);
     }
     await this.logger.info("Loaded metadata");
   }
@@ -1021,6 +1125,7 @@ export default class SyncManager {
    */
   async addConfigDirToMetadata() {
     await this.logger.info("Adding config dir to metadata");
+    const gitignoreMatcher = await this.getGitignoreMatcher();
     // Get all the files in the config dir
     let files = [];
     let folders = [this.vault.configDir];
@@ -1029,12 +1134,20 @@ export default class SyncManager {
       if (folder === undefined) {
         continue;
       }
+      if (isGitignored(gitignoreMatcher, folder, true)) {
+        await this.logger.info("Skipping .gitignore folder match", folder);
+        continue;
+      }
       const res = await this.vault.adapter.list(folder);
       files.push(...res.files);
       folders.push(...res.folders);
     }
     // Add them to the metadata store
     files.forEach((filePath: string) => {
+      if (isGitignored(gitignoreMatcher, filePath)) {
+        return;
+      }
+
       this.metadataStore.data.files[filePath] = {
         path: filePath,
         sha: null,

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -233,11 +233,8 @@ export default class SyncManager {
           return;
         }
 
-        if (targetPath === `${this.vault.configDir}/${LOG_FILE_NAME}`) {
-          // We don't want to download the log file if the user synced it in the past.
-          // This is necessary because in the past we forgot to ignore the log file
-          // from syncing if the user enabled configs sync.
-          // To avoid downloading it we ignore it if still present in the remote repo.
+        if (this.isVolatileSyncArtifact(targetPath)) {
+          await this.logger.info("Skipping volatile sync artifact", targetPath);
           return;
         }
 
@@ -588,8 +585,23 @@ export default class SyncManager {
     return filePath === `${this.vault.configDir}/${LOG_FILE_NAME}`;
   }
 
+  private isWorkspaceFile(filePath: string): boolean {
+    return (
+      filePath === `${this.vault.configDir}/workspace.json` ||
+      filePath === `${this.vault.configDir}/workspace-mobile.json`
+    );
+  }
+
+  private shouldSyncWorkspaceFiles(): boolean {
+    return this.settings.syncConfigDir && this.settings.syncWorkspaceFiles;
+  }
+
   private isVolatileSyncArtifact(filePath: string): boolean {
-    return this.isLogFile(filePath);
+    // Keep these files out of metadata when they should not be synced.
+    return (
+      this.isLogFile(filePath) ||
+      (this.isWorkspaceFile(filePath) && !this.shouldSyncWorkspaceFiles())
+    );
   }
 
   private filterRemoteMetadataFiles(filesMetadata: {
@@ -1143,10 +1155,6 @@ export default class SyncManager {
         folders.push(...res.folders);
       }
       files.forEach((filePath: string) => {
-        if (filePath === `${this.vault.configDir}/workspace.json`) {
-          // Obsidian recommends not syncing the workspace file
-          return;
-        }
         if (this.isVolatileSyncArtifact(filePath)) {
           return;
         }
@@ -1240,6 +1248,21 @@ export default class SyncManager {
         // We don't want to remove the metadata file even if it's in the config dir
         return;
       }
+      delete this.metadataStore.data.files[filePath];
+    });
+    this.metadataStore.save();
+  }
+
+  /**
+   * Removes workspace files from local metadata.
+   * Useful when the user disables workspace files synchronization.
+   */
+  async removeWorkspaceFilesFromMetadata() {
+    await this.logger.info("Removing workspace files from metadata");
+    [
+      `${this.vault.configDir}/workspace.json`,
+      `${this.vault.configDir}/workspace-mobile.json`,
+    ].forEach((filePath: string) => {
       delete this.metadataStore.data.files[filePath];
     });
     this.metadataStore.save();

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -452,8 +452,11 @@ export default class SyncManager {
     // commit the sync.
     let conflictResolutions: ConflictResolution[] = [];
 
-    const logConflictResolutions = conflicts
-      .filter((conflict) => this.isLogFile(conflict.filePath))
+    const autoResolvableLogConflicts = this.settings.autoResolveLogConflicts
+      ? conflicts.filter((conflict) => this.isLogFile(conflict.filePath))
+      : [];
+
+    const logConflictResolutions = autoResolvableLogConflicts
       .map((conflict) => ({
         filePath: conflict.filePath,
         content: conflict.localContent,
@@ -474,7 +477,9 @@ export default class SyncManager {
     }
 
     const remainingConflicts = conflicts.filter(
-      (conflict) => !this.isLogFile(conflict.filePath),
+      (conflict) =>
+        !this.settings.autoResolveLogConflicts ||
+        !this.isLogFile(conflict.filePath),
     );
 
     if (remainingConflicts.length > 0) {

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -452,37 +452,60 @@ export default class SyncManager {
     // commit the sync.
     let conflictResolutions: ConflictResolution[] = [];
 
-    if (conflicts.length > 0) {
-      await this.logger.warn("Found conflicts", conflicts);
+    const logConflictResolutions = conflicts
+      .filter((conflict) => this.isLogFile(conflict.filePath))
+      .map((conflict) => ({
+        filePath: conflict.filePath,
+        content: conflict.localContent,
+      }));
+    if (logConflictResolutions.length > 0) {
+      // Os logs são específicos de cada cofre e podem mudar em cada execução,
+      // por isso estes conflitos são resolvidos mantendo sempre o conteúdo local.
+      await this.logger.info(
+        "Automatically resolved log conflicts",
+        logConflictResolutions.map((resolution) => resolution.filePath),
+      );
+      conflictResolutions.push(...logConflictResolutions);
+      conflictActions.push(
+        ...logConflictResolutions.map((resolution: ConflictResolution) => {
+          return { type: "upload" as const, filePath: resolution.filePath };
+        }),
+      );
+    }
+
+    const remainingConflicts = conflicts.filter(
+      (conflict) => !this.isLogFile(conflict.filePath),
+    );
+
+    if (remainingConflicts.length > 0) {
+      await this.logger.warn("Found conflicts", remainingConflicts);
       if (this.settings.conflictHandling === "ask") {
         // Here we block the sync process until the user has resolved all the conflicts
-        conflictResolutions = await this.onConflicts(conflicts);
-        conflictActions = conflictResolutions.map(
-          (resolution: ConflictResolution) => {
-            return { type: "upload", filePath: resolution.filePath };
-          },
+        const manualConflictResolutions =
+          await this.onConflicts(remainingConflicts);
+        conflictResolutions.push(...manualConflictResolutions);
+        conflictActions.push(
+          ...manualConflictResolutions.map(
+            (resolution: ConflictResolution) => {
+              return { type: "upload" as const, filePath: resolution.filePath };
+            },
+          ),
         );
       } else if (this.settings.conflictHandling === "overwriteLocal") {
         // The user explicitly wants to always overwrite the local file
         // in case of conflicts so we just download the remote file to solve it
-
-        // It's not necessary to set conflict resolutions as the content the
-        // user expect must be the content of the remote file with no changes.
-        conflictActions = conflictResolutions.map(
-          (resolution: ConflictResolution) => {
-            return { type: "download", filePath: resolution.filePath };
-          },
+        conflictActions.push(
+          ...remainingConflicts.map((conflict: ConflictFile) => {
+            return { type: "download" as const, filePath: conflict.filePath };
+          }),
         );
       } else if (this.settings.conflictHandling === "overwriteRemote") {
         // The user explicitly wants to always overwrite the remote file
         // in case of conflicts so we just upload the remote file to solve it.
-
-        // It's not necessary to set conflict resolutions as the content the
-        // user expect must be the content of the local file with no changes.
-        conflictActions = conflictResolutions.map(
-          (resolution: ConflictResolution) => {
-            return { type: "upload", filePath: resolution.filePath };
-          },
+        conflictActions.push(
+          ...remainingConflicts.map((conflict: ConflictFile) => {
+            return { type: "upload" as const, filePath: conflict.filePath };
+          }),
         );
       }
     }
@@ -572,6 +595,10 @@ export default class SyncManager {
     ]);
 
     await this.commitSync(newTreeFiles, treeSha, conflictResolutions);
+  }
+
+  private isLogFile(filePath: string): boolean {
+    return filePath === `${this.vault.configDir}/${LOG_FILE_NAME}`;
   }
 
   /**

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -610,7 +610,7 @@ export default class SyncManager {
   }
 
   /**
-   * Remove artefactos volateis do metadata local para evitar conflitos recorrentes.
+   * Removes volatile artifacts from local metadata to prevent recurring conflicts.
    */
   private async removeVolatileArtifactsFromLocalMetadata() {
     let changed = false;
@@ -626,7 +626,7 @@ export default class SyncManager {
   }
 
   /**
-   * Reconcilia SHAs do metadata remoto com a tree atual para remover referencias obsoletas.
+   * Reconciles remote metadata SHAs with the current tree to remove stale references.
    */
   private async reconcileRemoteMetadataWithTree(
     remoteMetadataFiles: {
@@ -662,7 +662,7 @@ export default class SyncManager {
   }
 
   /**
-   * Tenta obter o blob pelo SHA do metadata e, em caso de 404, tenta pelo SHA atual da tree.
+   * Tries to load a blob by metadata SHA and, on 404, retries with the current tree SHA.
    */
   private async getRemoteFileContentWithFallback(
     filePath: string,

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -320,7 +320,12 @@ export default class SyncManager {
           return;
         }
 
-        if (targetPath.split("/").last()?.startsWith(".")) {
+        // O .gitignore também é um ficheiro escondido, mas tem de ser
+        // descarregado para manter as mesmas regras em todos os cofres.
+        if (
+          targetPath !== GITIGNORE_FILE_NAME &&
+          targetPath.split("/").last()?.startsWith(".")
+        ) {
           // We must skip hidden files as that creates issues with syncing.
           // This is fine as users can't edit hidden files in Obsidian anyway.
           await this.logger.info("Skipping hidden file", targetPath);

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -460,10 +460,10 @@ export default class SyncManager {
       .map((conflict) => ({
         filePath: conflict.filePath,
         content: conflict.localContent,
-      }));
+    }));
     if (logConflictResolutions.length > 0) {
-      // Os logs são específicos de cada cofre e podem mudar em cada execução,
-      // por isso estes conflitos são resolvidos mantendo sempre o conteúdo local.
+      // Logs are specific to each vault and can change on every run,
+      // so these conflicts are always resolved by keeping local content.
       await this.logger.info(
         "Automatically resolved log conflicts",
         logConflictResolutions.map((resolution) => resolution.filePath),


### PR DESCRIPTION
## Summary
Add a new `Sync workspace files` setting below `Sync configs`
Allow syncing `.obsidian/workspace.json` and `.obsidian/workspace-mobile.json` only when both config sync and workspace-file sync are enabled
Update metadata filtering and cleanup logic for workspace files